### PR TITLE
feat: Reclassify instrument not found as a warning

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -130,8 +130,9 @@ func (auth *Auth) Login(context *gin.Context, session sessions.Session) {
 	instrumentSettings, err := auth.BlaiseRestApi.GetInstrumentSettings(uacInfo.InstrumentName)
 	if err != nil {
 		if err == blaiserestapi.InstrumentNotFoundError {
-			auth.Logger.Error("Failed auth", append(utils.GetRequestSource(context),
+			auth.Logger.Warn("Failed auth", append(utils.GetRequestSource(context),
 				zap.String("Reason", "Instrument not installed"),
+				zap.String("Notes", "This can happen if a UAC for a non-Blaise 5 survey has been entered"),
 				zap.String("InstrumentName", uacInfo.InstrumentName),
 				zap.String("CaseID", uacInfo.CaseID),
 				zap.Error(err),

--- a/authenticate/authenticate_test.go
+++ b/authenticate/authenticate_test.go
@@ -111,6 +111,16 @@ var _ = Describe("Login", func() {
 			Expect(strings.Contains(string(body), `Please try again later or contact our Survey Enquiry Line on 0800 085 7376 for help.`)).To(BeTrue())
 			Expect(strings.Contains(string(body), `Any answers you have provided in previous sessions have been logged securely and confidentially. They will only be used for the purposes of this research.`)).To(BeTrue())
 		})
+
+		It("logs a warning", func() {
+			Expect(observedLogs.Len()).To(Equal(1))
+			Expect(observedLogs.All()[0].Message).To(Equal("Failed auth"))
+			Expect(observedLogs.All()[0].ContextMap()["Reason"]).To(Equal("Instrument not installed"))
+			Expect(observedLogs.All()[0].ContextMap()["Notes"]).To(Equal("This can happen if a UAC for a non-Blaise 5 survey has been entered"))
+			Expect(observedLogs.All()[0].ContextMap()["InstrumentName"]).To(Equal("foo"))
+			Expect(observedLogs.All()[0].ContextMap()["CaseID"]).To(Equal("bar"))
+			Expect(observedLogs.All()[0].Level).To(Equal(zap.WarnLevel))
+		})
 	})
 
 	Context("When instrument settings does not error", func() {


### PR DESCRIPTION
We are getting frequent alerts for this in production. Investigations
found that they are occuring due to UAC for different surveys being
entered into CAWI. This is a non-critical even so we have reduced the
error level.

Situations where this condition might occur are:

1. The questionnaire has been uninstalled but the UAC still exists - people are
    trying to complete an old questionnaire.
2. The UACs have been generated and sent out but the questionnaire has not yet
    been uploaded - people trying to complete a questionnaire which has not
    started.
3. Non-CAWI UACs are generated by BUS but the respondent enters them into CAWI.

Refs: BLAIS5-3206
