### PR TITLE
Potential fix for code scanning alert no. 8: Log entries created from user input

### DIFF
--- a/webserver/instrument_controller.go
+++ b/webserver/instrument_controller.go
@@ -163,7 +163,7 @@ func (instrumentController *InstrumentController) startInterviewAuth(context *gi
 
 	if !uacClaim.AuthenticatedForCase(startInterview.RuntimeParameters.KeyValue) {
 		instrumentController.Logger.Info("Not authenticated to start interview for case",
-			append(uacClaim.LogFields(), zap.String("CaseID", startInterview.RuntimeParameters.KeyValue))...)
+			append(uacClaim.LogFields(), zap.String("CaseID", sanitizeInput(startInterview.RuntimeParameters.KeyValue)))...)
 		authenticate.Forbidden(context, instrumentController.LanguageManager.IsWelsh(context))
 		return true
 	}
@@ -187,6 +187,7 @@ func (instrumentController *InstrumentController) proxy(context *gin.Context, ua
 
 	proxy.ServeHTTP(context.Writer, context.Request)
 }
+
 
 func (instrumentController *InstrumentController) logoutEndpoint(context *gin.Context) {
 	session := sessions.DefaultMany(context, "user_session")


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/blaise-cawi-portal/security/code-scanning/8](https://github.com/ONSdigital/blaise-cawi-portal/security/code-scanning/8)

To fix the problem, we need to sanitize the user input before logging it. Specifically, we should remove any newline characters from the user input to prevent log injection attacks. This can be done using the `strings.ReplaceAll` function to replace newline characters with an empty string. This ensures that the user input is safe to log and cannot be used to forge new log entries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
